### PR TITLE
fields remove their crops when the resolution date is reached

### DIFF
--- a/Assets/Farm.cs
+++ b/Assets/Farm.cs
@@ -39,17 +39,11 @@ public class Farm : MonoBehaviour
                     harvestedCrops.Add(field.Value.HarvestedCrop.Name, 0);
                 }
                 harvestedCrops[field.Value.HarvestedCrop.Name]++;
-                print(field.Value.HarvestedCrop.Name + ": " + harvestedCrops[field.Value.HarvestedCrop.Name]);
             }
         }
-        Debug.Log("Aged all field crops");
-        foreach (var crop in harvestedCrops)
-        {
-            print(crop.Key + ": " + crop.Value);
-        }
-
+        Debug.Log("aged crops");
         turnCausalityBreaches = validateCropFutures();
-        print("causal breaches: " + turnCausalityBreaches.ToString());
+        print("causal breaches: " + turnCausalityBreaches);
         print("accepted contracts: " + ledger.AcceptedContracts.Count);
         List<Contract> dueContracts = ledger.NextTurn(turn);
         print("due contracts: " + dueContracts.Count);
@@ -98,9 +92,9 @@ public class Farm : MonoBehaviour
     }
     int validateCropFutures()
     {
+        var causalityBreaches = 0;
         foreach (Field field in fields.Values)
         {
-            var causalityBreaches = 0;
             var resolvedFields = new List<Field>();
             var resolution = field.GetCausalityBreach(turn - turnsInYear);
             switch (resolution)

--- a/Assets/Field.cs
+++ b/Assets/Field.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 using System;
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using UnityEngine.U2D;
 public class Field
 {
+    Dictionary<string, Sprite> sprites = new Dictionary<string, Sprite>();
     UIDialog dialog;
     Crop crop;
     public Crop HarvestedCrop;
@@ -29,14 +31,19 @@ public class Field
         // 0: Resolved
         // -1: No futures
         string expectedCrop;
-        if (!futureCrops.TryGetValue(turn, out expectedCrop))
+        Debug.Log("future crops: " + futureCrops.Count);
+        if (futureCrops.TryGetValue(turn, out expectedCrop))
         {
+            Debug.Log("expected crop: " + expectedCrop);
             if (crop == null || expectedCrop != crop.Name)
             {
+                Debug.Log("missing: " + expectedCrop);
                 return 1;
             }
+            Debug.Log("found: " + crop.Name);
             return 0;
         }
+        Debug.Log("no future crop");
         return -1;
     }
     FieldMenu getFieldMenu()
@@ -67,6 +74,7 @@ public class Field
     public void HarvestCrop(int turn, Crop crop)
     {
         futureCrops.Add(turn, crop.Name);
+        Debug.Log("resolve one year from: " + turn);
         HarvestedCrop = crop;
     }
     public string GetCropName(){
@@ -75,6 +83,7 @@ public class Field
     public void DeleteCrop()
     {
         crop = null;
+        UpdateSprite(sprites["empty_field"]);
     }
     public void OnClick()
     {
@@ -107,5 +116,8 @@ public class Field
         this.dialog = dialogObj.GetComponent<UIDialog>();
         this.tilemap = tilemap;
         this.pos = pos;
+
+        SpriteAtlas atlas = Resources.Load<SpriteAtlas>("game-sprites");
+        sprites.Add("empty_field", atlas.GetSprite("empty_field"));
     }
 }


### PR DESCRIPTION
This changes completes some existing functions so that when a field expects a harvestable crop to exist on a given turn it either raises the causal breach indicator or removes the crop from its field.