### PR TITLE
fixed contract redemption and multiple harvest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 [Bb]uild/
 [Bb]uilds/
 [Ll]ogs/
+build.zip
 
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # [Aa]ssets/AssetStoreTools*

--- a/Assets/Contract.cs
+++ b/Assets/Contract.cs
@@ -16,14 +16,16 @@ public class Contract : IButton
     }
     public bool IsDue(int turn)
     {
-        return true;
+        Debug.Log(turn + ": " + Due);
+        return Due == turn;
     }
-    public Contract(string n, int v, Dictionary<string,int> c, Ledger l)
+    public Contract(string n, int v, Dictionary<string,int> c, Ledger l, int due)
     {
         Name = n;
         Value = v;
         Crops = c;
         ledger = l;
         Desc = string.Format("Value: {0:N0}", v);
+        Due = due;
     }
 }

--- a/Assets/Farm.cs
+++ b/Assets/Farm.cs
@@ -50,14 +50,10 @@ public class Farm : MonoBehaviour
     {
         print("turn end cash: " + cash);
         int turnCausalityBreaches = 0;
-        if (turnCount != null)
-        {
-            turn++;
-            turnCount.text = turn.ToString();
-        }
+        turn++;
+        turnCount.text = turn.ToString();
         foreach (var field in fields)
         {
-            field.Value.NextTurn();
             if (field.Value.HarvestedCrop != null)
             {
                 if (!harvestedCrops.ContainsKey(field.Value.HarvestedCrop.Name))
@@ -66,6 +62,7 @@ public class Farm : MonoBehaviour
                 }
                 harvestedCrops[field.Value.HarvestedCrop.Name]++;
             }
+            field.Value.NextTurn();
         }
         Debug.Log("aged crops");
         turnCausalityBreaches = validateCropFutures();
@@ -81,6 +78,12 @@ public class Farm : MonoBehaviour
         print("due contracts: " + dueContracts.Count);
         validateDueContracts(dueContracts);
         print("turn start cash: " + cash);
+        if (cash <= 0)
+        {
+            SceneController.EndGame();
+            return;
+        }
+        trader.NextTurn();
         updateTurnSummary();
     }
     void OnTileSelect()
@@ -130,7 +133,7 @@ public class Farm : MonoBehaviour
     {
         UIDialog turnDialog = turnDialogObj.GetComponent<UIDialog>();
         turnDialog.title.text = string.Format("Year: {0:N0} | Week: {1:N0}", (turn / 15) + 1, turn % 15);
-        turnDialog.buttonLister = new Turn(cash, causalityBreaches);
+        turnDialog.buttonLister = new TurnSummary(cash, causalityBreaches);
     }
     int validateCropFutures()
     {

--- a/Assets/Field.cs
+++ b/Assets/Field.cs
@@ -31,19 +31,14 @@ public class Field
         // 0: Resolved
         // -1: No futures
         string expectedCrop;
-        Debug.Log("future crops: " + futureCrops.Count);
         if (futureCrops.TryGetValue(turn, out expectedCrop))
         {
-            Debug.Log("expected crop: " + expectedCrop);
             if (crop == null || expectedCrop != crop.Name)
             {
-                Debug.Log("missing: " + expectedCrop);
                 return 1;
             }
-            Debug.Log("found: " + crop.Name);
             return 0;
         }
-        Debug.Log("no future crop");
         return -1;
     }
     FieldMenu getFieldMenu()
@@ -53,7 +48,7 @@ public class Field
         {
             fieldMenu = new Shop(this);
             // Debug.Log("new shop: " + fieldMenu.ToString());
-        } else if (Input.GetMouseButtonDown(1))
+        } else if (HarvestedCrop == null && Input.GetMouseButtonDown(1))
         {
             fieldMenu = new Harvest(this, turn);
             // Debug.Log("new harvest: " + fieldMenu.ToString());
@@ -67,6 +62,8 @@ public class Field
         if (fieldMenu != null)
         {
             actions = fieldMenu.Buttons;
+        } else {
+            actions = null;
         }
         // Debug.Log("actions count: " + actions.Count);
         actionLister = new ActionLister(actions);
@@ -88,10 +85,11 @@ public class Field
     public void OnClick()
     {
         UpdateActions();
-        dialog.buttonLister = actionLister;
-        // Debug.Log("actions: " + actionLister.Buttons.Count);
-        // Debug.Log("dialog: " + dialog.buttonLister.Buttons.Count);
-        dialog.ShowPanel();
+        if (actionLister.Buttons != null)
+        {
+            dialog.buttonLister = actionLister;
+            dialog.ShowPanel();
+        }
     }
     public void AddCrop(Crop crop)
     {
@@ -107,6 +105,7 @@ public class Field
     public void NextTurn()
     {
         turn++;
+        HarvestedCrop = null;
         if (crop == null) { return; }
         Sprite sprite = crop.NextTurn();
         UpdateSprite(sprite);

--- a/Assets/Trader.cs
+++ b/Assets/Trader.cs
@@ -8,8 +8,14 @@ public class Trader : IButtonLister
     public List<Contract> AvailableContracts { get { return availableContracts; } }
     public List<IButton> Buttons { get { return availableContracts.Cast<IButton>().ToList(); } }
     int counter = 1;
+    int turn = 1;
     Ledger ledger;
-    int maxContracts = 3;    
+    int maxContracts = 3;   
+    public void NextTurn()
+    {
+        turn++;
+        RefreshContracts();
+    } 
     public void RefreshContracts()
     {
         availableContracts = new List<Contract>();
@@ -19,8 +25,9 @@ public class Trader : IButtonLister
             Dictionary<string,int> crops = new Dictionary<string, int>(){
                {"Onion", 5}
             };
+            int due = turn + 1;
             availableContracts.Add(
-                new Contract(counter.ToString(), value, crops, ledger)
+                new Contract(counter.ToString(), value, crops, ledger, due)
             );
             counter++;
         }

--- a/Assets/TurnSummary.cs
+++ b/Assets/TurnSummary.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using UnityEngine;
+public class TurnSummary : IButtonLister
+{
+    public List<IButton> Buttons {get;} = new List<IButton>();
+    public TurnSummary(int cash, int causalityPoints)
+    {
+        this.Buttons.Add(new TurnItem("Current Cash", cash.ToString()));
+        this.Buttons.Add(new TurnItem("Causality Points", causalityPoints.ToString()));
+    }
+}

--- a/Assets/TurnSummary.cs.meta
+++ b/Assets/TurnSummary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bc5ba7e27419974cab585f7c708deeb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Introduced turn concept to Trader so that Contracts have a Due turn. Only on this turn can they be redeemed for their cash value (or rejected).

Added check to Field.OnClick to ensure that if actions are null that no menu is presented.