### PR TITLE
Make it clear whether the field menu is for harvest or shop

### DIFF
--- a/Assets/Crop.cs
+++ b/Assets/Crop.cs
@@ -6,7 +6,7 @@ public class Crop
 {
     public string Name {get;}
     int Age {get;set;}
-    int HarvestAge {get;}
+    public int HarvestAge {get;}
     int Value {get;}
     public int Cost {get;}
     public List<Sprite> sprites = new List<Sprite>();

--- a/Assets/Field.cs
+++ b/Assets/Field.cs
@@ -24,6 +24,12 @@ public class Field
             Buttons = actions;
         }
     }
+    enum fieldMenuEnum
+    {
+        Shop,
+        Harvest,
+        None,
+    }
     public int GetCausalityBreach(int turn)
     {
         // Return Codes
@@ -41,32 +47,28 @@ public class Field
         }
         return -1;
     }
-    FieldMenu getFieldMenu()
+    FieldMenu getFieldMenu(fieldMenuEnum fieldMenuType)
     {
         FieldMenu fieldMenu = null;
-        if (crop == null && Input.GetMouseButtonDown(0))
+        switch (fieldMenuType)
         {
-            fieldMenu = new Shop(this);
-            // Debug.Log("new shop: " + fieldMenu.ToString());
-        } else if (HarvestedCrop == null && Input.GetMouseButtonDown(1))
-        {
-            fieldMenu = new Harvest(this, turn);
-            // Debug.Log("new harvest: " + fieldMenu.ToString());
+            case fieldMenuEnum.Shop: 
+                fieldMenu = new Shop(this);
+                break;
+            case fieldMenuEnum.Harvest:
+                fieldMenu = new Harvest(this, turn);
+                break;
         }
         return fieldMenu;
     }
-    void UpdateActions()
+    void UpdateUIDialog(FieldMenu fieldMenu)
     {
-        // Debug.Log("updating actions");
-        var fieldMenu = getFieldMenu();
         if (fieldMenu != null)
         {
             actions = fieldMenu.Buttons;
-        } else {
-            actions = null;
+            dialog.buttonLister = new ActionLister(fieldMenu.Buttons);
+            dialog.SetTitle(fieldMenu.Name);        
         }
-        // Debug.Log("actions count: " + actions.Count);
-        actionLister = new ActionLister(actions);
     }
     public void HarvestCrop(int turn, Crop crop)
     {
@@ -84,10 +86,20 @@ public class Field
     }
     public void OnClick()
     {
-        UpdateActions();
-        if (actionLister.Buttons != null)
+        var fieldMenuType = fieldMenuEnum.None;
+        if (crop == null && Input.GetMouseButtonDown(0))
         {
-            dialog.buttonLister = actionLister;
+            fieldMenuType = fieldMenuEnum.Shop;
+            // Debug.Log("new shop: " + fieldMenu.ToString());
+        } else if (HarvestedCrop == null && Input.GetMouseButtonDown(1))
+        {
+            fieldMenuType = fieldMenuEnum.Harvest;
+            // Debug.Log("new harvest: " + fieldMenu.ToString());
+        }
+        FieldMenu fieldMenu = getFieldMenu(fieldMenuType);
+        if (fieldMenu != null)
+        {
+            UpdateUIDialog(fieldMenu);
             dialog.ShowPanel();
         }
     }

--- a/Assets/FieldMenu.cs
+++ b/Assets/FieldMenu.cs
@@ -3,6 +3,7 @@ using System;
 using UnityEngine;
 public class FieldMenu : IButtonLister
 {
+    public string Name { get; protected set;}
     Field field;
     public List<IButton> Buttons {get; protected set;} = new List<IButton>();
     public FieldMenu(Field field)

--- a/Assets/FieldMenuItem.cs
+++ b/Assets/FieldMenuItem.cs
@@ -3,9 +3,9 @@ public abstract class FieldMenuItem : IButton
 {
     protected Field field;
     public string Name {get;}
-    public string Desc {get;}
+    public string Desc {get; protected set;}
     public abstract void OnClick();
-    public FieldMenuItem(string name, string desc, Field field)
+    public FieldMenuItem(string name, Field field)
     {
         Name = name;
         this.field = field;

--- a/Assets/Harvest.cs
+++ b/Assets/Harvest.cs
@@ -5,6 +5,7 @@ public class Harvest : FieldMenu
 {
     public Harvest(Field field, int turn): base(field)
     {
+        Name = "Harvest";
         List<Crop> crops = new List<Crop>(){
             new Crop("Onion", 0, 5, 15, 5),
             new Crop("Potato", 0, 10, 45, 15),

--- a/Assets/HarvestItem.cs
+++ b/Assets/HarvestItem.cs
@@ -4,9 +4,15 @@ public class HarvestItem : FieldMenuItem
     Crop crop;
     int turn;
     public override void OnClick() => field.HarvestCrop(turn, crop);
-    public HarvestItem(Crop crop, int turn, Field field): base(crop.Name, null, field)
+    string formatDesc()
+    {
+        string template = "Cost: {0} | Turns: {1}";
+        return string.Format(template, crop.Cost, crop.HarvestAge);
+    }
+    public HarvestItem(Crop crop, int turn, Field field): base(crop.Name, field)
     {
         this.crop = crop;
         this.turn = turn;
+        base.Desc = formatDesc();
     }
 }

--- a/Assets/Shop.cs
+++ b/Assets/Shop.cs
@@ -5,6 +5,7 @@ public class Shop : FieldMenu
 {
     public Shop(Field field): base(field)
     {
+        Name = "Shop";
         List<Crop> crops = new List<Crop>(){
             new Crop("Onion", 0, 5, 15, 5),
             new Crop("Potato", 0, 10, 45, 15),

--- a/Assets/ShopItem.cs
+++ b/Assets/ShopItem.cs
@@ -6,8 +6,14 @@ public class ShopItem : FieldMenuItem
     private int GetCost()
     { return crop.Cost; }
     override public void OnClick() => base.field.AddCrop(crop);
-    public ShopItem(Crop crop, Field field): base(crop.Name, string.Format("Cost: {0:N0}", crop.Cost), field)
+    string formatDesc()
+    {
+        string template = "Cost: {0} | Turns: {1}";
+        return string.Format(template, crop.Cost, crop.HarvestAge);
+    }
+    public ShopItem(Crop crop, Field field): base(crop.Name, field)
     {
         this.crop = crop;
+        base.Desc = formatDesc();
     }
 }

--- a/Assets/UIDialog.cs
+++ b/Assets/UIDialog.cs
@@ -34,6 +34,10 @@ public class UIDialog : MonoBehaviour
         }
         gameObject.SetActive(true);
     }
+    public void SetTitle(string title)
+    {
+        this.title.text = title;
+    }
     public void SetButtons(List<IButton> lib)
     {
         if (lib == null) { return; }


### PR DESCRIPTION
Fixes #9

Updates FieldMenu and UIDialog so the name of the panel can be set as well as updates the FieldMenuItems so they add cost and turns to yield a crop in their descriptions.