### PR TITLE
update sprite when field is harvested

### DIFF
--- a/Assets/Crop.cs
+++ b/Assets/Crop.cs
@@ -9,7 +9,8 @@ public class Crop
     public int HarvestAge {get;}
     int Value {get;}
     public int Cost {get;}
-    public List<Sprite> sprites = new List<Sprite>();
+    List<Sprite> sprites = new List<Sprite>();
+    public Sprite HarvestSprite;
     List<string> stages = new List<string>(){
         "seed",
         "age",
@@ -38,5 +39,6 @@ public class Crop
         {
             sprites.Add(atlas.GetSprite("crop_" + stage));
         }
+        HarvestSprite = atlas.GetSprite("crop_" + "harvest");
     }
 }

--- a/Assets/Field.cs
+++ b/Assets/Field.cs
@@ -74,7 +74,8 @@ public class Field
     public void HarvestCrop(int turn, Crop crop)
     {
         futureCrops.Add(turn, crop.Name);
-        Debug.Log("resolve one year from: " + turn);
+        UpdateSprite(crop.HarvestSprite);
+        // Debug.Log("resolve one year from: " + turn);
         HarvestedCrop = crop;
     }
     public string GetCropName(){
@@ -119,10 +120,16 @@ public class Field
     public void NextTurn()
     {
         turn++;
-        HarvestedCrop = null;
-        if (crop == null) { return; }
-        Sprite sprite = crop.NextTurn();
-        UpdateSprite(sprite);
+        if (HarvestedCrop != null)
+        {
+            UpdateSprite(sprites["empty_field"]);
+            HarvestedCrop = null;
+        }
+        if (crop != null)
+        {
+            Sprite sprite = crop.NextTurn();
+            UpdateSprite(sprite);
+        }
     }
     public Field(GameObject dialogObj, Tilemap tilemap, Vector3Int pos, Farm farm)
     {

--- a/Assets/Resources/game-sprites.spriteatlas
+++ b/Assets/Resources/game-sprites.spriteatlas
@@ -61,6 +61,6 @@ SpriteAtlas:
   - wip-sprites_8
   - player
   - crop_ready
-  - shop_crop
+  - crop_harvest
   m_Tag: game-sprites
   m_IsVariant: 0

--- a/Assets/Scenes/Farm.unity
+++ b/Assets/Scenes/Farm.unity
@@ -607,6 +607,14 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_FlexibleHeight
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_PreferredHeight
+      value: -1
+      objectReference: {fileID: 0}
     - target: {fileID: 6079355494613499914, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
       propertyPath: m_Name
       value: Ledger
@@ -926,6 +934,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Turn
       objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8199419099307901660, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
@@ -1175,6 +1191,14 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_FlexibleHeight
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_PreferredHeight
+      value: -1
+      objectReference: {fileID: 0}
     - target: {fileID: 6079355494613499914, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
       propertyPath: m_Name
       value: TurnCount
@@ -1299,6 +1323,14 @@ PrefabInstance:
     - target: {fileID: 8199419097976028999, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
       propertyPath: m_Name
       value: Ledger
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8199419099307901660, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
       propertyPath: m_AnchorMin.y
@@ -1581,6 +1613,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Field
       objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8199419099307901660, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
@@ -1666,6 +1706,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2400395310544781958, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_ChildForceExpandHeight
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2687869101818447378, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
@@ -1885,6 +1929,14 @@ PrefabInstance:
     - target: {fileID: 8199419097976028999, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
       propertyPath: m_Name
       value: Trader
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199419099219194825, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8199419099307901660, guid: e3f0bdf54e8d9584b9a770d609f64307, type: 3}
       propertyPath: m_AnchorMin.y
@@ -3498,6 +3550,14 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_FlexibleHeight
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_PreferredHeight
+      value: -1
+      objectReference: {fileID: 0}
     - target: {fileID: 6079355494613499914, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
       propertyPath: m_Name
       value: NextTurn
@@ -3655,6 +3715,14 @@ PrefabInstance:
     - target: {fileID: 3136480279312842811, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_FlexibleHeight
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4081095592002977865, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
+      propertyPath: m_PreferredHeight
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6079355494613499914, guid: d2bd70e4a021ec049b80c1c916dbd04c, type: 3}
       propertyPath: m_Name

--- a/Assets/wip-sprites.png
+++ b/Assets/wip-sprites.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43850e0c030ccc8898aca1482429fa1526c4c9ef196eb57df52900b7f2986994
-size 3387
+oid sha256:48b27d02dcb2665b335a60544faaf486e9306c3ae6052fcb07877efe1b211ec7
+size 7395

--- a/Assets/wip-sprites.png.meta
+++ b/Assets/wip-sprites.png.meta
@@ -37,7 +37,7 @@ TextureImporter:
     second: grass
   - first:
       213: 7617126542778600300
-    second: shop_crop
+    second: crop_harvest
   externalObjects: {}
   serializedVersion: 11
   mipmaps:
@@ -416,7 +416,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: shop_crop
+      name: crop_harvest
       rect:
         serializedVersion: 2
         x: 64


### PR DESCRIPTION
Updated crops to have a harvest sprite and Field to set this sprite when the crop is harvested from the Field. To be addressed in future changes to ensure both existing crop and harvested state are visible during the turn and not overwriting each other.